### PR TITLE
ETHERSCAN_API_KEY to POLYGONSCAN_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 RPC=Your rpc endpoint
 MNEMONIC=here is where your twelve words mnemonic should be put my friend
 FORKING=false 
-POLYGONSCAN_API_KEY=YOUR ETHERSCAN_API_KEY
+POLYGONSCAN_API_KEY=YOUR POLYGONSCAN_API_KEY
 
 ## celo 0xe1c9e12d71caafdbd9912773f5a207a2179bd8b6
 ## whale cusd 0x1e0f3bfc926c4c4b98d428de9bbf0e5fa5909063


### PR DESCRIPTION
As we are using Polygon, we should use the "Polygonscan API Key" instead of the "Etherscan API Key"